### PR TITLE
Adds 'in/lastTappedTime' and 'in/lastShakenTime'

### DIFF
--- a/WebContent/index.html
+++ b/WebContent/index.html
@@ -17,6 +17,8 @@ If you have a Finch plugged in, use the following URLs to control it:
    <li>finch/in/accelerationX</li>
    <li>finch/in/accelerationY</li>
    <li>finch/in/accelerationZ</li>
+   <li>finch/in/lastTappedTime</li>
+   <li>finch/in/lastShakenTime</li>
    <li>finch/in/temperature</li>
    <li>finch/in/motor (provides current value of motor speeds)</li>
    <li>finch/in/led (provides current RGB color intensities of LED)</li>

--- a/src/birdbrain/finchandHummingbirdServer/FinchServlet.java
+++ b/src/birdbrain/finchandHummingbirdServer/FinchServlet.java
@@ -53,6 +53,8 @@ public class FinchServlet extends HttpServlet
    * in/accelerationY
    * in/accelerationZ
    * in/temperature
+   * in/lastTappedTime
+   * in/lastShakenTime
    *
    */
   
@@ -216,6 +218,12 @@ public class FinchServlet extends HttpServlet
 			  else if(urlPath.substring(4).equals("temperature")) {
 				  response.getWriter().print(Math.floor(finch.getTemperature()*100)/100);
 				 
+			  }
+			  else if(urlPath.substring(4).equals("lastTappedTime")) {
+				  response.getWriter().print(finch.getLastTappedTime());
+			  }
+			  else if(urlPath.substring(4).equals("lastShakenTime")) {
+				  response.getWriter().print(finch.getLastShakenTime());
 			  }
 			  // If the Finch is active and you wrote "in" but the remainder is garbage, send an error message
 			  else {

--- a/src/birdbrain/finchandHummingbirdServer/FinchServletWrapper.java
+++ b/src/birdbrain/finchandHummingbirdServer/FinchServletWrapper.java
@@ -14,6 +14,9 @@ public class FinchServletWrapper {
 	private Double temperature;
 	private boolean[] obstacles;
 	private int[] lights;
+	// The time when the last tapped and shaken events were recorded
+	private long lastTappedTime = 0;
+	private long lastShakenTime = 0;
 	
 	// We poll sensors in a separate thread to minimize the timer doGet has to wait
 	private Thread sensorLoop;
@@ -29,6 +32,12 @@ public class FinchServletWrapper {
 					{
 						try {
 							// Each finch.get takes 8 ms, then sleep to allow other things to happen
+							if (finch.isTapped())
+								lastTappedTime = System.currentTimeMillis();
+							Thread.sleep(12);
+							if (finch.isShaken())
+								lastShakenTime = System.currentTimeMillis();
+							Thread.sleep(12);
 							accelerations = finch.getAccelerations();
 							Thread.sleep(12);
 							temperature = finch.getTemperature();
@@ -144,8 +153,16 @@ public class FinchServletWrapper {
 		
 	}	
 	
-	
-	
+	public long getLastTappedTime() {
+		return lastTappedTime;
+	}
+
+	public long getLastShakenTime() {
+		return lastShakenTime;
+	}
+
+
+
 	// Parses the Finch output string and sets it
 	public boolean setOutput(String setter)
 	{


### PR DESCRIPTION
For example:

http://localhost:22179/finch/in/lastTappedTime
http://localhost:22179/finch/in/lastShakenTime

These URLS will output a timestamp of the last time the respective event was read from the Finch.  Clients can use the timestamp to determine whether a shaken or tapped event has occurred since the last time they checked by simply comparing the new timestamp against a prior value.